### PR TITLE
Is41#apply mods for ploys

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -2992,12 +2992,15 @@
       "license": "MIT"
     },
     "node_modules/baseline-browser-mapping": {
-      "version": "2.9.19",
-      "resolved": "https://registry.npmjs.org/baseline-browser-mapping/-/baseline-browser-mapping-2.9.19.tgz",
-      "integrity": "sha512-ipDqC8FrAl/76p2SSWKSI+H9tFwm7vYqXQrItCuiVPt26Km0jS+NzSsBWAaBusvSbQcfJG+JitdMm+wZAgTYqg==",
+      "version": "2.11.13",
+      "resolved": "https://registry.npmjs.org/baseline-browser-mapping/-/baseline-browser-mapping-2.11.13.tgz",
+      "integrity": "sha512-k9HNuUVMlqVjQ9UHzfPjIqiDbWw7WqT1AoT7GL8VwvF3r0ZfArtgiSPAlmupyNquNgOJHTuH4CKYf8ttMTWBTQ==",
       "license": "Apache-2.0",
       "bin": {
-        "baseline-browser-mapping": "dist/cli.js"
+        "baseline-browser-mapping": "dist/cli.cjs"
+      },
+      "engines": {
+        "node": ">=6.0.0"
       }
     },
     "node_modules/bcp-47-match": {
@@ -3173,9 +3176,9 @@
       }
     },
     "node_modules/caniuse-lite": {
-      "version": "1.0.30001727",
-      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001727.tgz",
-      "integrity": "sha512-pB68nIHmbN6L/4C6MH1DokyR3bYqFwjaSs/sWDHGj4CTcFtQUQMuJftVwWkXq7mNWOybD3KhUv3oWHoGxgP14Q==",
+      "version": "1.0.30001809",
+      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001809.tgz",
+      "integrity": "sha512-xxWVywk6a6Arlk+hymeycyn/VgqEfLDxupvhH/xiY5SJ/18kmi9o6MiO320DCUzypORHLtvh0I4i04tUhCNHNQ==",
       "funding": [
         {
           "type": "opencollective",

--- a/prisma/generateSeedData.ts
+++ b/prisma/generateSeedData.ts
@@ -39,7 +39,8 @@ async function exportCoreData() {
       ploys,
     ] = await Promise.all([
       prisma.opType.findMany({ where: { killteamId: { in: killteams.map(kt => kt.killteamId) } }, orderBy: { seq: 'asc' } }),
-      prisma.equipment.findMany({ where: { killteamId: { in: killteams.map(kt => kt.killteamId) } }, orderBy: { seq: 'asc' } }),
+      // killteamId: null rows are universal equipment - `in` never matches NULL, so it must be OR'd in explicitly
+      prisma.equipment.findMany({ where: { OR: [{ killteamId: { in: killteams.map(kt => kt.killteamId) } }, { killteamId: null }] }, orderBy: { seq: 'asc' } }),
       prisma.ploy.findMany({ where: { killteamId: { in: killteams.map(kt => kt.killteamId) } }, orderBy: { seq: 'asc' } })
     ])
 

--- a/prisma/seed-data.json
+++ b/prisma/seed-data.json
@@ -23101,6 +23101,110 @@
       "eqName": "Chaos Talismans",
       "description": "**STRATEGIC GAMBIT**\nSelect one Marks of Chaos keyword.\nOnce during each of their activations, when a friendly LEGIONARY operative that has that keyword is shooting, fighting or retaliating, if you roll two or more fails,\nyou can inflict D3 damage on that friendly operative to discard one of them and retain the other as a normal success instead.\nNote that if it is the Shoot action and that damage incapacitates that friendly operative, the action does not end (continue the sequence with your successful attack dice).",
       "effects": ""
+    },
+    {
+      "eqId": "UNIVERSAL-UE-AC",
+      "killteamId": null,
+      "seq": 1,
+      "eqName": "Ammo Cache (x1)",
+      "description": "Before the battle, you can set up one of your Ammo Cache markers wholly within your territory. Friendly operatives can perform the following mission action during the battle: AMMO RESUPPLY (0 AP): One of your Ammo Cache markers the active operative controls is used during this turning point.\n\nUntil the start of the next turning point, whenever this operative is shooting with a weapon from its datacard, you can re-roll one of your attack dice.\n\nAn operative cannot perform this action while within control range of an enemy operative, if that marker is not yours, or if that marker has been used this turning point.",
+      "effects": ""
+    },
+    {
+      "eqId": "UNIVERSAL-UE-RW",
+      "killteamId": null,
+      "seq": 2,
+      "eqName": "Razor Wire (x1)",
+      "description": "Razor wire is Exposed and Obstructing terrain. Before the battle, you can set it up wholly within your territory, on the killzone floor and more than 2\" from other equipment terrain features, access points, and Accessible terrain.\n\nObstructing: Whenever an operative would cross over this terrain feature within 1\" of it, treat the distance as an additional 1\".",
+      "effects": ""
+    },
+    {
+      "eqId": "UNIVERSAL-UE-CD",
+      "killteamId": null,
+      "seq": 3,
+      "eqName": "Comms Device (x1)",
+      "description": "Before the battle, you can set up one of your Comms Device markers wholly within your territory. While a friendly operative controls this marker, add 3\" to the distance requirements of its SUPPORT rules that refer to friendly operatives (e.g. ‘select one friendly operative within 6\"’ would be 9\" instead). Note that you cannot benefit from your opponent's Comms Device markers.",
+      "effects": ""
+    },
+    {
+      "eqId": "UNIVERSAL-UE-MIN",
+      "killteamId": null,
+      "seq": 4,
+      "eqName": "Mines (x1)",
+      "description": "Before the battle, you can set up one of your Mines markers wholly within your territory and more than 2\" from other markers, access points, and Accessible terrain. The first time that marker is within an operative's control range, remove that marker and inflict D3+3 damage on that operative.",
+      "effects": ""
+    },
+    {
+      "eqId": "UNIVERSAL-UE-LB",
+      "killteamId": null,
+      "seq": 5,
+      "eqName": "Light Barricades (x2)",
+      "description": "Light barricades are Light terrain, except the feet, which are Insignificant and Exposed. Before the battle, you can set up any of them wholly within your territory, on the killzone floor and more than 2\" from other equipment terrain features, access points, and Accessible terrain.",
+      "effects": ""
+    },
+    {
+      "eqId": "UNIVERSAL-UE-HB",
+      "killteamId": null,
+      "seq": 6,
+      "eqName": "Heavy Barricade (x1)",
+      "description": "A heavy barricade is Heavy terrain. Before the battle, you can set it up wholly within 4\" of your drop zone, on the killzone floor and more than 2\" from other equipment terrain features, access points, and Accessible terrain.",
+      "effects": ""
+    },
+    {
+      "eqId": "UNIVERSAL-UE-LAD",
+      "killteamId": null,
+      "seq": 7,
+      "eqName": "Ladders (x2)",
+      "description": "Ladders are Insignificant and Exposed terrain. Before the battle, you can set up any of them as follows:\n\n- Wholly within your territory.\n- Upright against terrain that’s at least 2\" tall.\n- More than 2\" from other equipment terrain features.\n- More than 1\" from doors and access points.\n\nOnce per action, whenever an operative is climbing the terrain feature a ladder is placed against, treat the vertical distance as 1\" if the ladder is within that operative’s control range during that entire climb.",
+      "effects": ""
+    },
+    {
+      "eqId": "UNIVERSAL-UE-PB",
+      "killteamId": null,
+      "seq": 8,
+      "eqName": "Portable Barricade (x1)",
+      "description": "A portable barricade is Light, Protective and Portable terrain, except the feet which are Insignificant and Exposed. Before the battle, you can set it up wholly within your territory, on the killzone floor and more than 2\" from other equipment terrain features, access points, and Accessible terrain.\n\nProtective: While an operative is in cover from this terrain feature, improve its Save stat by 1 (to a maximum of 2+).\n\nPortable: This terrain feature only provides cover while an operative is connected to it and if the shield is intervening (ignore its feet). Operatives connected to the inside of it can perform the following unique action during the battle:\n\nMove With Barricade (1 AP): The same as the Reposition action, except the active operative can move no more than its Move stat minus 2\" and cannot climb, drop, jump, or use any killteam's rules that remove it and set it back up again (e.g. HEARTHKYN SALVAGER Fly, MANDRAKE Shadow Passage).\n\nBefore this operative moves, remove the portable barricade it is connected to. After it moves, set up the portable barricade so it is connected again, but the portable barricade cannot be set up within 2\" of other equipment terrain features, access points or Accessible terrain. If this is not possible, the portable barricade is not set up again.\n\nThis action is treated as a Reposition action. An operative cannot perform this action while within control range of an enemy operative, or in the same activation in which it performed the Fall Back or Charge action.",
+      "effects": ""
+    },
+    {
+      "eqId": "UNIVERSAL-UE-UG-SMOKE",
+      "killteamId": null,
+      "seq": 9,
+      "eqName": "Utility Grenade - Smoke (x1/2)",
+      "description": "When you select this equipment, select two utility grenades (2 smoke, 2 stun, or 1 smoke and 1 stun). Each selection is a unique action your operatives can perform, but your kill team can only perform that action a total number of times during the battle equal to your selection.\n\nSMOKE GRENADE (1 AP):\n\nPlace one of your Smoke Grenade markers within 6\" of this operative. It must be visible to this operative, or on Vantage terrain of a terrain feature that is visible to this operative. The marker creates an area of smoke 1\" horizontally and unlimited height vertically from (but not below) it.\nWhile an operative is wholly within an area of smoke, it is obscured to operatives more than 2\" from it, and vice versa. In addition, whenever an operative is shooting an enemy operative wholly within an area of smoke, weapons with the Piercing 2 or Piercing Crits 2 weapon rule have the Piercing 1 or Piercing Crits 1 weapon rule (respectively) instead, unless they’re within 2\" of each other.\nIn the Ready step of the next Strategy phase, roll one D3. Remove that Smoke Grenade marker after a number of activations equal to that D3 have been completed or at the end of the turning point (whichever comes first).\nAn operative cannot perform this action while within control range of an enemy operative, or if you have reached the total number of times your kill team can perform it.",
+      "effects": ""
+    },
+    {
+      "eqId": "UNIVERSAL-UE-UG-STUN",
+      "killteamId": null,
+      "seq": 10,
+      "eqName": "Utility Grenade - Stun (x1/2)",
+      "description": "When you select this equipment, select two utility grenades (2 smoke, 2 stun, or 1 smoke and 1 stun). Each selection is a unique action your operatives can perform, but your kill team can only perform that action a total number of times during the battle equal to your selection.\n\nSTUN GRENADE (1 AP):\n\nSelect one enemy operative visible to and within 6\" of this operative. That operative and each other operative within 1\" of it takes a stun test. For an operative to take a stun test, roll one D6: on a 3+, subtract 1 from its APL stat until the end of its next activation.\nAn operative cannot perform this action while within control range of an enemy operative, or if you have reached the total number of times your kill team can perform it.",
+      "effects": ""
+    },
+    {
+      "eqId": "UNIVERSAL-UE-XG-FRAG",
+      "killteamId": null,
+      "seq": 11,
+      "eqName": "Explosive Grenade - Frag (x1/2)",
+      "description": "When you select this equipment, select two explosive grenades (2 frag, 2 krak, or 1 frag and 1 krak).\n\n|**Name**|**ATK**|**HIT**|**DMG**|\n|-----|:-----:|:-----:|:-----:|\n|Frag Grenade|4|4+|2/4|\n|**Weapon Rules**|\n|Rng 6\", Blast 2\", Saturate|\n",
+      "effects": "ADDWEP:Frag Grenade|R|4|4+|2/4|Rng 6\", Blast 2\", Sat"
+    },
+    {
+      "eqId": "UNIVERSAL-UE-XG-KRAK",
+      "killteamId": null,
+      "seq": 12,
+      "eqName": "Explosive Grenade - Krak (x1/2)",
+      "description": "When you select this equipment, select two explosive grenades (2 frag, 2 krak, or 1 frag and 1 krak).\n\n|**Name**|**ATK**|**HIT**|**DMG**|\n|-----|:-----:|:-----:|:-----:|\n|Krak Grenade|4|4+|4/5|\n|**Weapon Rules**|\n|Rng 6\", Piercing 1, Saturate|\n",
+      "effects": "ADDWEP:Krak Grenade|R|4|4+|4/5|Rng 6\", Prc1, Sat"
+    },
+    {
+      "eqId": "UNIVERSAL-UE-BC",
+      "killteamId": null,
+      "seq": 13,
+      "eqName": "Breaching Charge",
+      "description": "Once per battle, when a friendly operative performs the Breach action, you can use this rule. If you do, that operative can perform that action for 1 less AP (to a minimum of 1AP) as though it had the word \"breach marker\" on its datacard.",
+      "effects": ""
     }
   ],
   "options": [

--- a/src/components/op/OpCard.tsx
+++ b/src/components/op/OpCard.tsx
@@ -1,12 +1,13 @@
 'use client'
 
+import { badgeClass } from '@/components/shared/Links'
 import { useLocalSettings } from '@/hooks/useLocalSettings'
 import { getOpPortraitUrl, toEpochMs } from '@/lib/utils/imageUrls'
 import { showInfoModal } from '@/lib/utils/showInfoModal'
-import { getOpTypeUniqueAbilitiesAndOptions, getOpUniqueAbilitiesAndOptions, getShortOpTypeName } from '@/lib/utils/utils'
+import { getOpTypeUniqueAbilitiesAndOptions, getOpUniqueAbilitiesAndOptions, getShortOpTypeName, parsePloyCPCost } from '@/lib/utils/utils'
 import { WeaponRule } from '@/lib/utils/weaponRules'
 import WeaponTable from '@/src/components/shared/WeaponTable'
-import { KillteamPlain, OpPlain, OpTypePlain, RosterPlain } from '@/types'
+import { KillteamPlain, OpPlain, OpTypePlain, PloyPlain, RosterPlain } from '@/types'
 import { Menu, MenuButton } from '@headlessui/react'
 import MDEditor, { commands } from '@uiw/react-md-editor'
 import { useEffect, useState } from 'react'
@@ -85,6 +86,19 @@ export default function OpCard({
   const { abilities: opTypeUniqueAbilities, options: opTypeUniqueOptions } = op.isOpType
     ? getOpTypeUniqueAbilitiesAndOptions(killteam ?? roster?.killteam ?? undefined, op as OpTypePlain)
     : { abilities: [], options: [] }
+
+  // Active Strategy ploys are usually passive round-long effects, not something you "use" - shown as Effects
+  const activePloyIds = !op.isOpType ? (roster?.ployIds?.split(',').filter(Boolean) ?? []) : []
+  const killteamPloys: PloyPlain[] = (killteam ?? roster?.killteam)?.ploys ?? []
+  const activeStrategyEffects = killteamPloys.filter((p) => p.ployType === 'S' && activePloyIds.includes(p.ployId))
+  // Firefight ploys (ployType !== 'S', matches RosterPloys.tsx convention) are always usable for CP, so list them
+  // as reference options regardless of the roster's active-ploy toggle state
+  const firefightPloyOptions = killteamPloys.filter((p) => p.ployType !== 'S')
+
+  // Equipment-derived options are tagged with the equipment's own eqId, which never collides with a native optionId format
+  const activeEquipmentIds = new Set((roster?.equipments ?? []).map((eq) => eq.eqId))
+  const nativeOptions = op.options?.filter((opt) => !activeEquipmentIds.has(opt.optionId)) ?? []
+  const equipmentOptions = op.options?.filter((opt) => activeEquipmentIds.has(opt.optionId)) ?? []
 
   useEffect(() => {
     !op.isOpType && setNewCurrWOUNDS(op.currWOUNDS ?? 0)
@@ -284,11 +298,27 @@ export default function OpCard({
           </div>
         )}
 
-        {/* Options */}
-        {!isCollapsed && (op.options?.length ?? 0) > 0 && (op.isOpType || (op.currWOUNDS !== 0 && op.isDeployed)) && (
+        {/* Effects - active Strategy ploys, passive for the round while selected */}
+        {!isCollapsed && activeStrategyEffects.length > 0 && (op.isOpType || (op.currWOUNDS !== 0 && op.isDeployed)) && (
+          <div className="border-t border-border grid grid-cols-2 mt-2">
+            <h6 className="text-muted">Effects</h6>
+            {activeStrategyEffects.map((ploy) => (
+              <span
+                key={ploy.ployId}
+                onClick={() => showDesc(ploy.ployName, ploy.description)}
+                className="cursor-pointer hover:text-main truncate overflow-hidden mr-2"
+              >
+                {ploy.ployName}
+              </span>
+            ))}
+          </div>
+        )}
+
+        {/* Options - OpType-native, equipment-derived (non-weapon), and Firefight ploys (always usable for CP) */}
+        {!isCollapsed && (nativeOptions.length + equipmentOptions.length + firefightPloyOptions.length) > 0 && (op.isOpType || (op.currWOUNDS !== 0 && op.isDeployed)) && (
           <div className="border-t border-border grid grid-cols-2 mt-2">
             <h6 className="text-muted">Options</h6>
-            {op.options?.map((opt) => (
+            {nativeOptions.map((opt) => (
               <span 
                 key={opt.optionId}
                 onClick={() => showDesc(opt.optionName, opt.description)} 
@@ -297,6 +327,29 @@ export default function OpCard({
                 {opt.optionName}
               </span>
             ))}
+            {equipmentOptions.map((opt) => (
+              <span 
+                key={opt.optionId}
+                onClick={() => showDesc(opt.optionName, opt.description)} 
+                className="cursor-pointer hover:text-main truncate overflow-hidden mr-2"
+              >
+                {opt.optionName.replace(/^Eq:\s*/, '')}
+              </span>
+            ))}
+            {firefightPloyOptions.map((ploy) => {
+              // Firefight ploys cost 1CP unless the ploy text states otherwise
+              const cpCost = parsePloyCPCost(ploy.description) ?? 1
+              return (
+                <span
+                  key={ploy.ployId}
+                  onClick={() => showDesc(ploy.ployName, ploy.description)}
+                  className="cursor-pointer hover:text-main truncate overflow-hidden mr-2 flex items-center gap-1"
+                >
+                  {ploy.ployName}
+                  <span className={`${badgeClass} text-xs shrink-0`}>{cpCost}CP</span>
+                </span>
+              )
+            })}
           </div>
         )}
 

--- a/src/lib/utils/utils.ts
+++ b/src/lib/utils/utils.ts
@@ -83,6 +83,12 @@ export function sanitizeFileName(fileName: string): string {
     .toLowerCase(); // Optionally make it lowercase for consistency
 }
 
+// Ploys have no structured CP-cost field; best-effort extract it from the free-text description
+export function parsePloyCPCost(description: string): number | null {
+  const match = description.match(/(\d+)\s*CP/i)
+  return match ? parseInt(match[1], 10) : null
+}
+
 export function getOpUniqueAbilitiesAndOptions(roster?: RosterPlain, op?: OpPlain) {
   if (!op || !roster) {
     return { abilities: [], options: [] }

--- a/src/services/roster.service.ts
+++ b/src/services/roster.service.ts
@@ -58,9 +58,10 @@ export class RosterService {
         const weaponEffects = filteredEffectTokens.filter((token) => token.startsWith('ADDWEP'))
         const nonWeaponEffects = filteredEffectTokens.filter((token) => !token.startsWith('ADDWEP'))
 
-        // If this equipment has a non-weapon effect, add it to the operative's options
-        // UNLESS it's a "No equipment" operative type
-        if (nonWeaponEffects.length > 0) {
+        // Always surface selected equipment as an Option for reference, unless it purely grants a weapon
+        // (already visible in the Weapons table) with no other rules text to show
+        const isWeaponOnly = weaponEffects.length > 0 && nonWeaponEffects.length === 0 && filteredEffectTokens.length > 0
+        if (!isWeaponOnly) {
           const option = new Option ({
             optionId: eq.eqId,
             optionName: 'Eq: ' + eq.eqName,


### PR DESCRIPTION
This pull request enhances the operatives' card display by surfacing active strategy ploys as passive effects, always showing firefight ploys as options, and improving the handling of equipment-derived options. Additionally, it adds a utility function to parse command point (CP) costs from ploy descriptions and makes the equipment query logic more robust to include universal equipment.

**Operative Card UI Improvements:**

- In `OpCard.tsx`, surfaced active Strategy ploys as passive "Effects" and always listed Firefight ploys as options with their CP cost, improving clarity and usability for players. Equipment-derived options are now also shown distinctly. [[1]](diffhunk://#diff-ae20324f9a9f9b9499eda1e14fde2b1f31ecd47f00feb5f4acc6a263e1ac52c4R90-R102) [[2]](diffhunk://#diff-ae20324f9a9f9b9499eda1e14fde2b1f31ecd47f00feb5f4acc6a263e1ac52c4L287-R321) [[3]](diffhunk://#diff-ae20324f9a9f9b9499eda1e14fde2b1f31ecd47f00feb5f4acc6a263e1ac52c4R330-R352)

**Utility and Service Enhancements:**

- Added `parsePloyCPCost` utility to extract CP cost from ploy descriptions, used to display CP costs for Firefight ploys in the UI.
- Improved logic in `RosterService` to always surface selected equipment as an option unless it purely grants a weapon, ensuring non-weapon effects are always visible to the user.

During testing, I also noticed that universal equipment was missing from the seed data and I attempted to add it manually since I could not replicate the migration from a database I did not have. Using data from the live version, I attempted to add it to `seed-data.json`.

**Universal Equipment Support:**

- Added universal equipment entries (with `killteamId: null`) to `prisma/seed-data.json`, enabling all kill teams to access a standard set of equipment.
- Updated the equipment query in `generateSeedData.ts` to explicitly include universal equipment by OR'ing in `killteamId: null` rows, ensuring they're not omitted from results. #